### PR TITLE
Simplify multicode CSS styles

### DIFF
--- a/_less/screen.less
+++ b/_less/screen.less
@@ -782,20 +782,20 @@ table td,table th{
 .toccontent a.term:visited code{
 	color:#646464;
 }
-
-.toccontent .multicode {
+.toccontent .multicode{
 	background-color:#f5f5f5;
-	border:1px solid #ccc;
 	overflow-y:auto;
-	padding-bottom: 34px;
+	padding:17px;
+	border:1px solid #ccc;
+	-webkit-border-radius:3px;
+	-moz-border-radius:3px;
+	border-radius:3px;
 }
-
-.toccontent .multicode pre {
-	border: 0px none;
-	padding-top: 0px;
-	padding-bottom: 0px;
-	overflow-y: visible;
-	margin-bottom: -17px;
+.toccontent .multicode pre{
+	border:0px none;
+	padding:0;
+	margin:0;
+	overflow-y:visible;
 }
 
 .anchorAf{


### PR DESCRIPTION
This one makes padding / margin of each CSS rule more independent of each other (to make it a little easier to understand, and harder to break by changing padding / margin on the default "pre" CSS code).

It also adds missing border-radius, so these code boxes look identical to non-multicode ones.

Except for border-radius, the visual result should remain unchanged.
