### PR TITLE
Move Gavin's Payment Request Generator to the "Examples" page

### DIFF
--- a/_includes/example_payment_processing.md
+++ b/_includes/example_payment_processing.md
@@ -21,6 +21,9 @@ aware of the payment protocol, it accesses the URL specified in the `r`
 parameter, which should provide it with a serialized PaymentRequest
 served with the [MIME][] type `application/bitcoin-paymentrequest`<!--noref-->.
 
+**Resource:** Gavin Andresen's [Payment Request Generator][] generates
+custom example URIs and payment requests for use with testnet.
+
 {% endautocrossref %}
 
 #### PaymentRequest & PaymentDetails

--- a/_includes/guide_payment_processing.md
+++ b/_includes/guide_payment_processing.md
@@ -402,9 +402,6 @@ users and software don't need to worry about payments being sent to
 addresses which are no longer monitored.)  See the Refunds section below
 for more details.
 
-**Resource:** Gavin Andresen's [Payment Request Generator][] generates
-custom example URIs and payment requests for use with testnet.
-
 {% endautocrossref %}
 
 ### Verifying Payment


### PR DESCRIPTION
Just a suggestion, but I felt this was better suited for the "Examples" page and would be more visible here, since this allows real testing.
