### PR TITLE
Format "protocol versions" table content to improve readability

### DIFF
--- a/_includes/ref_p2p_networking.md
+++ b/_includes/ref_p2p_networking.md
@@ -56,11 +56,11 @@ document older protocol versions, please [open an issue][docs issue].)
 
 | Version | Implementation                      | Major Changes
 |---------|-------------------------------------|--------------
-| 70002   | Bitcoin Core 0.9.0 (March 2014)     | Added `reject` message (see [BIP61][]).  Send multiple `inv` messages in response to `mempool` message if necessary.
-| 70001   | Bitcoin Core 0.8.0 (February 2013)  | Added `filterload` message, `filteradd` message, `filterclear` message, and `merkleblock` message; also added relay field to `version` message and `MSG_FILTERED_BLOCK` inventory type to `getdata` message (see [BIP37][]).
-| 60002   | Bitcoin Core 0.7.0 (September 2012) | Added `mempool` message and extended `getdata` message to allow download of memory pool transactions (see [BIP35][]).
-| 60001   | Bitcoin Core 0.6.1 (May 2012)       | Added `pong` message (see [BIP31][]).
-| 60000   | Bitcoin Core 0.6.0 (March 2012)     | Separated protocol version from Bitcoin Core version (see [BIP14][]).
+| 70002   | Bitcoin Core 0.9.0 <br>(Mar. 2014)  | - Added `reject` message (see [BIP61][]). <br>- Send multiple `inv` messages in response to `mempool` message if necessary.
+| 70001   | Bitcoin Core 0.8.0 <br>(Feb. 2013)  | - Added `filterload` message. <br>- Added `filteradd` message. <br>- Added `filterclear` message. <br>- Added `merkleblock` message; also added relay field to `version` message and `MSG_FILTERED_BLOCK` inventory type to `getdata` message (see [BIP37][]).
+| 60002   | Bitcoin Core 0.7.0 <br>(Sep. 2012)  | - Added `mempool` message. <br>- Extended `getdata` message to allow download of memory pool transactions (see [BIP35][]).
+| 60001   | Bitcoin Core 0.6.1 <br>(May. 2012)  | - Added `pong` message (see [BIP31][]).
+| 60000   | Bitcoin Core 0.6.0 <br>(Mar. 2012)  | - Separated protocol version from Bitcoin Core version (see [BIP14][]).
 
 {% endautocrossref %}
 


### PR DESCRIPTION
I thought this could improve readability a little while not adding too much HTML.

Current version: http://dg0.dtrt.org/en/developer-reference#protocol-versions

Screenshot:

![capture du 2014-11-14 20 01 38](https://cloud.githubusercontent.com/assets/3578089/5055881/bb4b19b8-6c39-11e4-8000-35d19014d829.png)
