### PR TITLE
Adjust pageoffset to update the "Edit On GitHub" link correctly

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -430,7 +430,7 @@ function updateSource(e){
 if (!document.getElementsByClassName) return;
 var t = getEventTarget(e),
     nodes = document.getElementsByClassName('sourcefile'),
-    pageoffset = getPageYOffset(),
+    pageoffset = Math.max(0, getPageYOffset() + 100),
     windowy = getWindowY(),
     fallback = nodes[0],
     first = [fallback, getTop(fallback)],


### PR DESCRIPTION
The "Edit On GitHub" link isn't updated when you click to any anchor because the subhead links are displayed right after the title. This pull request lets javascript update the link before (when at >=100px near the subhead links).

For example, the "Edit On GitHub" link should point to the "transactions" source file when clicking on this link, but it doesn't: http://dg2.dtrt.org/en/developer-guide#transactions
